### PR TITLE
Added google tracking code to yaml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,13 @@ plugins:
   - jekyll-remote-theme
   - "jekyll-seo-tag"
 
+
+
+#google analytics
+ga_tracking: G-CJZGLX01YZ
+ga_tracking_anonymize_ip: true
+
+
 # Build settings
 remote_theme: pmarsceill/just-the-docs
 


### PR DESCRIPTION
### Added Google Tracking Code to YAML

**Work Process:**

1. Created google analytics account through personal Google account.
2. Added domain "http://docs.snowiq.net/" as tracking property.
3. Acquired tracking ID (Google Analytics 4).
4. Inputted tracking ID into config as per JTD documentation.
<img width="779" alt="Screen Shot 2021-07-02 at 10 13 55 PM" src="https://user-images.githubusercontent.com/55544989/124340412-14bc1000-db83-11eb-881f-e8e69ccfa8e2.png">

(View diff)


**Possible Next Steps:**

1. Push to live site
2. Access site
3. Check google Analytics to confirm everything is working

Please let me know if there are any questions.