### PR TITLE
Headings: modification to anchor tags

### DIFF
--- a/da-drivers-activity.md
+++ b/da-drivers-activity.md
@@ -11,13 +11,13 @@ comments: true
 ---
 
 <section id="Drivers-Activity" markdown="1">
-# Driver's Activity<a name="Drivers-Activity"></a>
+# Driver's Activity
 
 <section id="Assignments" markdown="1">
-## Assignments<a name="Assignments"></a>
+## Assignments
 
 <section id="Accepting-and-Working-Assignments" markdown="1">
-### Accepting and Working Assignments<a name="Accepting-and-Working-Assignments"></a>
+### Accepting and Working Assignments
 When a Supervisor assigns a route, a ticket, or an address-specific assignment, the Driver receives a notification as seen below. Press 'Ok' and follow the steps below:
 
 <img src="image/driver/accepting-assignments-ios.png" class="ios"/>
@@ -29,7 +29,7 @@ When a Supervisor assigns a route, a ticket, or an address-specific assignment, 
 </section>
 
 <section id="Completing-Assignments" markdown="1">
-### Completing Assignments<a name="Completing-Assignments"></a> 
+### Completing Assignments
 A Driver can complete their Active Assignment by opening the Navigation drawer and pressing 'Complete Assignment' as seen below.
 
 <img src="image/driver/completing-assignment-ios.png" class="ios"/>
@@ -42,7 +42,7 @@ This removes the assignment from the Status bar and also moves it from Active As
 </section>
 
 <section id="Completing-Multi-Pass-Assignment" markdown="1">
-### Completing Multi-Pass Assignment<a name="Completing-Multi-Pass-Assignment"></a>
+### Completing Multi-Pass Assignment
 If a Driver receives an Assignment with Multi-pass toggled on, it will be indicated in the notification. Once the Driver completes a pass, they will press 'Complete Pass' in the Navigation drawer and will await further instructions from the supervisor as specified in the status bar as seen below. 
   - If a Supervisor chooses another pass for this assignment, the Driver will receive the following notification to proceed work on the multi-pass assignment until completed with the pass and repeat the steps as specified above.
 
@@ -59,7 +59,7 @@ If a Driver receives an Assignment with Multi-pass toggled on, it will be indica
 
 
 <section id="PausedResumed-Assignment" markdown="1">
-### Paused/Resumed Assignment<a name="Paused/Resumed-Assignment"></a>
+### Paused/Resumed Assignment
 When a Supervisor pauses a Driver, the Driver's status changes to 'Paused' and the status bar is updated, as shown below. Once the Supervisor resumes the Driver, the previous Assignment is started again and the status returns to 'In Service.'
 
 <img src="image/driver/paused-resumed-assignment-ios.png" class="ios"/>

--- a/da-installing-drivers-app.md
+++ b/da-installing-drivers-app.md
@@ -10,19 +10,27 @@ platform: true
 comments: true
 ---
 
-# Installing the Driver App
+<section id="Installing-Driver-App" markdown="1">
+# Installing Driver App
 
 The app, titled "SnowIQ Driver," can be found on both the <a href="https://play.google.com/store/apps/details?id=com.eastbanctech.transitiq.snowtrax&hl=en_US&gl=US">Google Play</a> and <a href="https://apps.apple.com/us/app/snowiq-driver/id1336056235">Apple App Store</a>. It is published by EastBanc Technologies. In order to use the app, navigate to the app's page on the App Store and download the app.
 
 <img src="image/driver/app-store-ios.png" class="ios" width="500"/>
 <img src="image/driver/app-store-android.png" class="android" width="500"/>
 
+<section id="Download" markdown="1">
+## Download
 Once you have navigated to the app store, hit the "GET" button and wait for the app to download. Once it has downloaded, navigate to your phone's home screen. There, you will find the SNOWiQ Driver app. 
 
 <img src="image/driver/app-home-screen-ios.png" class="ios" width="500"/>
 <img src="image/driver/app-home-screen-android.png" class="android" width="500"/>
+</section>
 
+<section id="Set-up-and-Permissions" markdown="1">
+## Set-up and Permissions
 Tap the icon on your home screen to open the app. Upon opening the app, you will be asked for permission to access your location, camera and microphone. In order to proceed, you must give the app these permissions. After giving these permssions, you will be able to login.
 
 <img src="image/driver/app-permissions-ios.png" class="ios" width="500"/>
 <img src="image/driver/app-permissions-android.png" class="android" width="500"/>
+</section>
+</section>

--- a/da-login-and-navigation.md
+++ b/da-login-and-navigation.md
@@ -13,7 +13,7 @@ comments: true
 # Login and Navigation
 
 <section id="Login" markdown="1">
-## Login<a name="Login"></a>
+## Login
 The login screen below allows Driver users to enter the SNOWiQ Driver Application (DA). Click the appropriate 'Login' button to be re-routed to enter the assigned username and password for the application.
 
 <img src="image/driver/login.png"/>
@@ -29,7 +29,7 @@ Once logged into the DA, Drivers will see the screen below. The screens display 
 </section>
 
 <section id="Navigation" markdown="1">
-## Navigation<a name="-Navigation"></a>
+## Navigation
 The diagram below highlights basic navigation controls and map elements of the Driver App.
 
 <img src="image/driver/navigation-ios.png" class="ios"/>
@@ -56,21 +56,21 @@ The diagram below highlights basic navigation controls and map elements of the D
 14. Button "Find my location on the map"
 
 <section id="Navigation-Drawer" markdown="1">
-### Navigation Drawer<a name="-Navigation-Drawer"></a>
+### Navigation Drawer
 Users can open the Navigation Drawer by pressing the User Profile picture icon as specified in the diagram above. The panel is divided into three sections:
 
 <section id="User-Profile-Details" markdown="1">
-#### User Profile Details<a name="-User-Profile-details"></a>
+#### User Profile Details
 This section lists the profile details of logged in driver. To edit them, the user can press 'Profile' in the section below.
 </section>
 
 <section id="Supervisor-Details" markdown="1">
-#### Supervisor Details<a name="Supervisor-details"></a>
+#### Supervisor Details
 Each driver has a Supervisor they report to and who assigns them work. The Supervisor's name and phone number are listed in this section, with the ability to contact the Supervisor directly from within the app, by pressing the green phone icon.
 </section>
 
 <section id="Operations-Menu" markdown="1">
-#### Operations Menu<a name="Operations"></a>
+#### Operations Menu
 The Operations Menu as seen above is for a Driver without any active or future assignments. If a driver receives an assignment or needs to complete an active assignment, an actionable option will be added to the menu, which can be seen here.
 
 <img src="image/driver/navigation-drawer-ios.png" class="ios"/>
@@ -79,7 +79,7 @@ The Operations Menu as seen above is for a Driver without any active or future a
 </section>
 
 <section id="Assignments" markdown="1">
-### Assignments<a name="Assignments"></a>
+### Assignments
 A user can press on 'Assignments' to view the Active Assignment, if there is one, any Future Assignments in the queue, and the History of assignments the driver worked on.
 
 <img src="image/driver/assignments-ios.png" class="ios"/>
@@ -87,7 +87,7 @@ A user can press on 'Assignments' to view the Active Assignment, if there is one
 </section>
 
 <section id="Profile" markdown="1">
-### Profile<a name="Profile"></a>
+### Profile
 A user can press on 'Profile' to edit their name, phone number, and User Picture.
 
 <img src="image/driver/profile-ios.png" class="ios"/>
@@ -95,7 +95,7 @@ A user can press on 'Profile' to edit their name, phone number, and User Picture
 </section>
 
 <section id="Salt-Management" markdown="1">
-### Salt Management<a name="Salt-Management"></a>
+### Salt Management
 A Driver user can press on 'Salt Management' to record how much salt was loaded and returned by pressing 'Add Salt Usage Info.' The historical usage is saved in the list, as seen below. 
 
 <img src="image/driver/salt-management-ios.png" class="ios"/>
@@ -103,14 +103,13 @@ A Driver user can press on 'Salt Management' to record how much salt was loaded 
 </section>
 
 <section id="About" markdown="1">
-### About<a name="-About"></a>
+### About
 Displays the current version of the app.
 </section>
 
 <section id="Logout" markdown="1">
-### Logout<a name="-Logout"></a>
+### Logout
 A user must logout at the end of each workday.
 </section>
-
 </section>
 </section>

--- a/da-overview.md
+++ b/da-overview.md
@@ -9,7 +9,7 @@ has_children: true
 platform: false
 ---
 
-## Driver App (DA) <a name="-Driver-App"></a>
+## Driver App (DA)
 **Audience: Drivers**
 
 This mobile application is accessed on plow drivers’ (contractor or county employee) mobile device. This application allows drivers to view their current assigned routes, their progress, and set the status of their route to "Completed" in order to move on to their next assignment.

--- a/da-road-hazards.md
+++ b/da-road-hazards.md
@@ -13,7 +13,7 @@ comments: true
 # Road Hazards
 
 <section id="Creating-Road-Hazards" markdown="1">
-## Creating Road Hazards<a name="Creating-Road-Hazards"></a>
+## Creating Road Hazards
 A Driver can create a road hazard on the map to warn other Drivers of the hazards on their routes, by following the steps below:
   - On the map, press the road hazard plus icon
   - The system will display the 'New road hazard' prompt shown below
@@ -32,7 +32,7 @@ A Driver can create a road hazard on the map to warn other Drivers of the hazard
 </section>
 
 <section id="Deleting-Road-Hazards" markdown="1">
-## Deleting Road Hazards<a name="Deleting-Road-Hazards"></a>
+## Deleting Road Hazards
 A Driver can delete an existing road hazard from the map if it doesn't exist anymore: 
   - Press on an existing road hazard on the map
   - The system will display the following 'Road hazard info' prompt

--- a/guide-and-term-dictionary.md
+++ b/guide-and-term-dictionary.md
@@ -13,7 +13,7 @@ platform: false
 
 
 <section id="What-is-SNOWiQ" markdown="1">
-## What is SNOWiQ?<a name="What-is-SNOWiQ"></a>
+## What is SNOWiQ?
     
 SNOWiQ is a snowplow fleet management and reporting tool for municipalities, snow plow operators, and the public. Based on our TERRAiQ platform, SNOWiQ uses a combination of smartphone-based GPS and cloud technology, delivering a 360-degree view of individual contractor vehicles and your overall snow removal fleet, without costly hardware investments.  Your team and drivers simply log into the SNOWiQ app from the smartphones and devices they already own. SNOWiQ is a Software as a Service (SaaS) solution that combines your internal reporting needs with the convenience of a public dashboard—two mobile applications and a citizen web portal that satisfies all your vehicle tracking, business intelligence, and communication needs. SNOWiQ is designed to meet the unique needs of fleet supervisors, snowplow operators, and the public they serve.
 
@@ -25,31 +25,31 @@ SNOWiQ is a snowplow fleet management and reporting tool for municipalities, sno
 </section>
 
 <section id="Application-Summaries" markdown="1">
-## Application Summaries<a name= "Application-Summaries"></a>
+## Application Summaries
 
 <section id="Storm-Operations-Center-SOC" markdown="1">
-### Storm Operations Center (SOC)<a name="-Storm-Operations-Center-(SOC)"></a> 
+### Storm Operations Center (SOC)
 **Audience: Storm Operations Managers and Supervisors**
 
 This application is primarily used for planning purposes by the SOC Manager to plan and create storm events, review and send 311 tickets to their respective depots, and view the current progress of all actions currently involved in the county. This application is Web-based but can be accessed on mobile devices (iPads, tablets, etc.), if needed. Old documentation refers to this web applications as Admin Portal.
 </section>
 
 <section id="Supervisor-App-SA" markdown="1">
-### Supervisor App (SA)<a name="Supervisor-App"></a>
+### Supervisor App (SA)
 **Audience: Supervisors and Inspectors**
 
 This mobile application is used to create driver assignments for upcoming storm events, create address specific route assignments, view and manage driver assignment progress, and view and manage 311 tickets that are assigned by Storm Operations Managers/Supervisors from the SOC.
 </section>
 
 <section id="Driver-App-DA" markdown="1">
-### Driver App (DA)<a name="Driver-App"></a>
+### Driver App (DA)
 **Audience: Drivers**
 
 This mobile application is accessed on plow drivers’ (contractor or county employee) mobile device. This application allows drivers to view their current assigned routes, their progress, and set the status of their route to "Completed" in order to move on to their next assignment.
 </section>
 
 <section id="Resident-Portal-RP" markdown="1">
-### Resident Portal (RP)<a name="Resident-Portal-(RP)"></a>
+### Resident Portal (RP)
 
 This web-based application allows residents of the county to view statistics about the current storm event and view data on the progress of different phases (salting, plowing, etc.).
 
@@ -57,21 +57,21 @@ This web-based application allows residents of the county to view statistics abo
 </section>
 
 <section id="Roles-in-SNOWiQ-SOC-User-Management" markdown="1">
-## Roles in SNOWiQ (SOC-User Management)<a name="-SNOWiQ-(SOC-User-Management"></a>
+## Roles in SNOWiQ (SOC-User Management)
 <section id="Admin" markdown="1">
-### Admin<a name="Admin"></a>
+### Admin
 
 The Admin's primary role is to plan upcoming storm events once storm season begins. They are responsible for creating the events in the Snow Operations Center (SOC), along with setting up the phases for supervisors to create assignments for drivers. They will mainly use the SNOWiQ SOC for planning and management.
 </section>
 
 <section id="Supervisor" markdown="1">
-### Supervisor<a name="-Supervisor"></a>
+### Supervisor
 
 Supervisors are managers over specific depots (potentially more than one) and are responsible for the management of phases and driver assignments. Supervisors also work with the Storm Operations Managers during storm events planning to create phases and driver assignments. Supervisors have access to the SNOWiQ SOC for planning and the SNOWiQ Supervisor Application (SA) to create assignments, stop and start phases, and review 311 tickets for assignment. Supervisors can only view routes assigned to their depot, which is automatically set to their default depot. 
 </section>
 
 <section id="Inspector" markdown="1">
-### Inspector<a name="-Inspector"></a>
+### Inspector
 
 Inspectors are responsible for the management of assignments and ensuring the completion of those assignments by reviewing the work done by the drivers on site once the job is completed. Supervisors primarily work in the SNOWiQ Supervisor Application (SA) to manage specific routes and to review 311 Requests to create assignments for drivers.
 
@@ -79,52 +79,52 @@ Currently Supervisors and Inspectors have the same access (both SA and SOC). The
 </section>
 
 <section id="Driver" markdown="1">
-### Driver<a name="-Driver"></a>
+### Driver
 
 Drivers are responsible for assignments sent to them by Storm Operations Managers, supervisors, or inspectors. This could include a pre-determined route, a specific address, or queued assignments for multiple phases during a storm event. Assignments may include plowing, salting, a combination of plowing and salting, or multi-pass assignments. Drivers will use the SNOWiQ Driver App on their mobile device to receive assignments and act on those assignments to completion.
 </section>
 
 <section id="Resident" markdown="1">
-### Resident<a name="Resident"></a>
+### Resident
 
 Residents have the ability to log into the SNOWiQ Resident Portal to view statistics of the current storm event for the entire county, a specific service area (depot), or a route that their address is associated with. This allows users to get a better understanding of what actions are currently underway in reference to the current situation.
 </section>
 </section>
 
 <section id="SNOWiQ-Vocabulary" markdown="1">
-## SNOWiQ Vocabulary<a name="SNOWiQ-Vocabulary"></a>
+## SNOWiQ Vocabulary
 
 <section id="Season" markdown="1">
-### Season<a name="Season"></a>
+### Season
 
 When a Season is referenced in conjunction with SNOWiQ, it typically means a period of time in which there is an increased chance of snowfall in the area and personnel should be available for snow cleanup and emergency request duties.
 </section>
 
 <section id="Event" markdown="1">
-### Event<a name="Event"></a>
+### Event
 
 An Event is a single entity created by a Storm Operations Manager to create a plan for an upcoming snow storm (typically 1-2 weeks before the actual storm).
 </section>
 
 <section id="Phase" markdown="1">
-### Phase<a name="-Phase"></a>
+### Phase
 
 Phases are used during a Storm Event to define certain Activities to be done by the drivers at a specific time. An example of a Phase would be 'Plowing' - a Phase with an Activity set to 'Plowing' would set all assignments to this activity and drivers included in this phase would need to plow their assigned routes. One phase must be completed before the next can begin as they cannot overlap.
 </section>
 
 <section id="Depot" markdown="1">
-### Depot<a name="Depot"></a>
+### Depot
 
 A Depot is a centralized hub that manages a number of routes in the service area. Typically, a single Supervisor manages a depot. A Depot can potentially have multiple Inspectors that manage individual routes within the service area.
 </section>
 
 <section id="Driver-1" markdown="1">
-### Driver<a name="Driver"></a> 
+### Driver
 
 See ‘Driver’ Definition under the ‘Roles’ section above. When logged into the app, Storm Operations Managers, supervisors, and inspectors will be able to see the driver markers on an interactive map along with their current status at the time (notated by a color specified in Status below). County employees can be found on the map with a circular snowplow marker while contractors will be found with a square marker.
 
 <section id="Driver-Status" markdown="1">
-#### Driver Status<a name="Driver-Status"></a>
+#### Driver Status
   * Logged in (Contractor Only) –  is for Contract Drivers who have logged into the system, but have not accepted any new assignments and are not working on any active assignments. This status is for drivers awaiting a new status after logging in. (This status means no payment is being calculated for the driver, whether they just logged on or have been released.)
   * Standby (Contractor Only) – is for Contract Drivers who are in position, awaiting assignment. This status is applied manually to a driver by their supervisor. (This status allows for calculation of payment by half of their rate.)  
   * Ready – is the default status for County Drivers after logging on. For Contract Drivers, it is applied manually by their supervisor to indicate that the driver is ready to begin work on another assignment. (This status allows for calculation of payment in the Contract Driver's full rate.)
@@ -138,12 +138,12 @@ See ‘Driver’ Definition under the ‘Roles’ section above. When logged int
 </section>
 
 <section id="Route" markdown="1">
-### Route<a name="Route"></a>
+### Route
 
 A numbered geo-located path line within a depot that was previously uploaded into SOC that is used in assignments to drivers along with a status indicator (color-coded based on route status). Route is a combination of route segments with one or more segment type (emergency, primary or neighborhood). A Route can have multiple assignments and drivers attached to it.
 
 <section id="Route-Type" markdown="1">
-#### Route Type<a name="Route-Type"></a>
+#### Route Type
 
 **Emergency:** These routes have priority over Residential routes - when selected in an assignment these routes are to be worked first. Depending on the active route plan settings, emergency route could be represented by either just emergency (red) road segments or  combination of emergency (red) road segments and primary (blue) road segments.
 
@@ -151,7 +151,7 @@ A numbered geo-located path line within a depot that was previously uploaded int
 </section>
 
 <section id="Route-Status" markdown="1">
-#### Route Status<a name="Route-Status"></a>
+#### Route Status
 * Unassigned - When there are no assignments created for the route
 * In Progress - The route has one of the four status below. This aggregated status is used when using filters throughout all applications for simplification.
     * Pending - When there is at least one assignment but it hasn't been accepted by the Driver yet.
@@ -167,12 +167,12 @@ A numbered geo-located path line within a depot that was previously uploaded int
 </section>  
 
 <section id="Assignment" markdown="1">
-### Assignment<a name="Assignment"></a>
+### Assignment
 
 An Assignment is a task created within a phase by a supervisor and assigned to a driver to be completed. An assignment can be for an existing route, an address specific route, or a 311 ticket, and it can be an active assignment that the driver is working on or a future one.
 
 <section id="Assignment-Status" markdown="1">
-#### Assignment Status<a name="-Assignment-Status"></a>
+#### Assignment Status
 * Paused - When a Supervisor pauses a Driver and if the Driver had an Active Assignment that is paused as well.
 * Pending - When a Supervisor creates a new Assignment that hasn't been accepted by the Driver.
 * Accepted - When a Driver has accepted the assignment.
@@ -186,7 +186,7 @@ An Assignment is a task created within a phase by a supervisor and assigned to a
 </section>
 
 <section id="MC311-Request-and-Emergency-Tickets" markdown="1">
-### MC311 Request and Emergency Tickets<a name="MC311-Request-and-Emergency-Tickets"></a>
+### MC311 Request and Emergency Tickets
 
 MC311 ticket requests are imported from the Montgomery County 311 system where residents report snow-related issues, whereas emergency tickets are specific requests from 3rd parties like emergency services to plow a route to a specific location.
 * SR ID - Service Request ID.
@@ -201,7 +201,7 @@ MC311 ticket requests are imported from the Montgomery County 311 system where r
 * Route ID - which route is associated with the ticket.
 
 <section id="Ticket-Status" markdown="1">
-#### Ticket Status<a name="Ticket-Status"></a>
+#### Ticket Status
 
 * New - The system checked that the 311 ticket is valid for assignment or a new emergency ticket was created but not sent out for assignment yet.
 * Sent - The Admin user reviewed the ticket and sent it to Supervisor App (SA) for assignment creation.

--- a/sa-drivers-tab-view.md
+++ b/sa-drivers-tab-view.md
@@ -10,9 +10,9 @@ platform: true
 comments: true
 ---
 <section id="Drivers-Tab-View" markdown="1">
-# Driver's Tab View<a name="-Drivers-Tab-View"></a>
+# Driver's Tab View
 
-The Drivers panel displays a list of drivers active in the system with their names and current statuses. The driver marker is displayed on the map (color coded based on status). Above the list there is a set of filters: by Depot, Route Type, and Route Status. Pressing on the name of the driver in the panel on the left takes the user to the [Driver Details](#-Driver-Details)
+The Drivers panel displays a list of drivers active in the system with their names and current statuses. The driver marker is displayed on the map (color coded based on status). Above the list there is a set of filters: by Depot, Route Type, and Route Status. Pressing on the name of the driver in the panel on the left takes the user to the [Driver Details](#Driver-Details)
 
 <img src="image/supervisor/drivers-tab-android.png" class="android"/>
 <img src="image/supervisor/drivers-tab-ios.png" class="ios"/>
@@ -23,18 +23,18 @@ Pressing on the driver marker on the map (the snowplow icon) produces a prompt o
 <img src="image/supervisor/drivers-tab1-ios.png" class="ios"/>
 
 <section id="Drivers-Filters" markdown="1">
-## Drivers Filters<a name="Drivers-Filters"></a>
+## Drivers Filters
 
 Using the filters above the drivers list allows users to narrow down what is seen on the map. Setting a filter can add or remove map elements such as driver types or drivers with different statuses. The filters and their options are listed below:
 
 <section id="Depot" markdown="1">
-### Depot<a name="Depot"></a>
+### Depot
 
 The depot filter defaults to the depot the Supervisor is assigned to and only the drivers associated with that depot will be displayed. 
 </section>
 
 <section id="Driver-Type" markdown="1">
-### Driver Type<a name="Driver-Type"></a>
+### Driver Type
 
 The Route Type filter allows users to filter by County or Contractor employees. County employees can be found on the map with a circular snowplow marker while contractors will be found with a square marker 
 <img src="image/supervisor/driver-logo.png"/>
@@ -42,7 +42,7 @@ The Route Type filter allows users to filter by County or Contractor employees. 
 </section>
 
 <section id="Driver-Status" markdown="1">
-### Driver Status<a name="-Driver-Status"></a>
+### Driver Status
 
 The Driver Status filter allows users to view drivers with a specific status only.
 
@@ -57,7 +57,7 @@ The Driver Status filter allows users to view drivers with a specific status onl
 </section>
 
 <section id="Driver-Details" markdown="1">
-## Driver Details<a name="-Driver-Details"></a>
+## Driver Details
 
 The Driver Details panel focuses on one selected driver both on the map and on the left-hand panel and all the details associated with that driver: Active Assignments, if any, and their progress, history of previous assignments and future ones. Here, the Supervisor is also able to 
 1. 'Pause' (or 'Resume' not shown) an Active Assignment, which would notify the Driver in the Driver App that their Assignment has been paused.  

--- a/sa-login-and-navigation.md
+++ b/sa-login-and-navigation.md
@@ -13,7 +13,7 @@ comments: true
 # Login and Navigation
 
 <section id="Login" markdown="1">
-## Login<a name="Login"></a>
+## Login
 
 The login screen below allows Supervisor users to enter into
 the SNOWiQ Supervisor Application. Click the 'Login' button
@@ -31,7 +31,7 @@ with that depot.
 </section>
 
 <section id="Navigation" markdown="1">
-## Navigation<a name="Navigation"></a>
+## Navigation
  
 The diagram below highlights basic navigation controls and map elements of the Supervisor App 
 
@@ -60,7 +60,7 @@ The diagram below highlights basic navigation controls and map elements of the S
 17. Notification banner - displays active event estimates. Pressing on the banner opens up the Event Log
 
 <section id="Settings-Menu" markdown="1">
-### Settings Menu<a name="Setting-Menu"></a>
+### Settings Menu
  
 Users can navigate to the Settings Menu by pressing the 'Gear' icon as specified in the diagram above. The menu opens to the 'My Profile' page automatically. The following menu options are available:
 
@@ -69,19 +69,19 @@ Users can navigate to the Settings Menu by pressing the 'Gear' icon as specified
 </section>
 
 <section id="My-Profile" markdown="1">
-#### My Profile<a name="My-Profile"></a>
+#### My Profile
  
 A user can edit their own profile by pressing 'Edit Profile' in the top right corner, as can be seen in the screenshot above, which would allow the user to edit their own information such as name, phone number and email.
 </section>
 
 <section id="About" markdown="1">
-#### About<a name="-About"></a>
+#### About
  
 Displays the current version of the app.
 </section>
 
 <section id="Event-Log" markdown="1">
-#### Event Log<a name="Event-Log"></a>
+#### Event Log
  
 The Event Log allows Supervisor users a closer look at the actions, users and timestamps of the actions for the current actice Event. As seen below, the log shows the time the action occurred in the system, what the action was, and who performed the action (username or system). Actions may include creating an Assignment or activating a new Phase for a Depot.
 
@@ -90,7 +90,7 @@ The Event Log allows Supervisor users a closer look at the actions, users and ti
 </section>
 
 <section id="Map-Layers" markdown="1">
-### Map Layers<a name="-Map-Layers"></a>
+### Map Layers
  
 A user can access the Map Layers panel by pressing the Map Layers icon on the map (stack of layers icon as shown below). By selecting the elements from the panel, a user can specify which markers or segments to be displayed on the map, subjected to filters selected in the left-hand panel.
 
@@ -99,7 +99,7 @@ A user can access the Map Layers panel by pressing the Map Layers icon on the ma
 </section>
 
 <section id="Clusters" markdown="1">
-### Clusters<a name="Clusters"></a>
+### Clusters
  
 On the Map Monitoring view, When a user zooms outs, markers with numbers inside them appear called 'clusters' that de-clutter the map and group together like markers. Clicking on a cluster allows to user to zoom in on that area and view the separated markers on the map.
 </section>

--- a/sa-overview.md
+++ b/sa-overview.md
@@ -10,7 +10,7 @@ platform: false
 ---
 
 
-## Supervisor App (SA) <a name="-Supervisor-App"></a>
+## Supervisor App (SA)
 **Audience: Supervisors and Inspectors**
 
 This mobile application is used to create driver assignments for upcoming storm events, create address specific route assignments, view and manage driver assignment progress, and view and manage 311 tickets that are assigned by Storm Operations Managers/Supervisors from the SOC.

--- a/sa-routes-tab-view.md
+++ b/sa-routes-tab-view.md
@@ -10,7 +10,7 @@ platform: true
 comments: true
 ---
 <section id="Routes-Tab-View" markdown="1">
-# Routes Tab View<a name="-Routes-Tab-View"></a>
+# Routes Tab View
 
 A panel on the left has three tabs: Routes, Drivers, and Tickets. The app opens to Routes, as seen below.
 
@@ -20,18 +20,18 @@ The Route panel displays a list of routes with their corresponding route name/nu
 <img src="image/supervisor/routes-tab-ios.png" class="ios"/>
 
 <section id="Route-Filters" markdown="1">
-## Route Filters<a name="-Route-Filters"></a>
+## Route Filters
 
 Using the filters above the route list allows users to narrow down what is seen on the map. Setting a filter can add or remove map elements such as route outlines, routes of different types (priorities), or routes with different statuses. The filters and their options are listed below:
 
 <section id="Depot" markdown="1">
-### Depot<a name="Depot"></a>
+### Depot
 
 The depot filter defaults to the depot the Supervisor is assigned to and only the routes associated with that depot will be displayed. 
 </section>
 
 <section id="Route-Type-Priority" markdown="1">
-### Route Type (Priority)<a name="-Route-Type-(Priority)"></a>
+### Route Type (Priority)
 
 The Route Type filter allows users to filter out route outlines that belong to specific route priorities (not to be confused with route segment type). Route is a combination of route segments with one or more segment type (emergency, primary or neighborhood).
 
@@ -41,7 +41,7 @@ The Route Type filter allows users to filter out route outlines that belong to s
 </section>
 
 <section id="Route-Status" markdown="1">
-### Route Status<a name="-Route-Status"></a>
+### Route Status
 
 The Route Status filter allows users to view any routes set to a specific status during an assignment.
 
@@ -52,7 +52,7 @@ The Route Status filter allows users to view any routes set to a specific status
 </section>
 </section>
 <section id="Route-Details" markdown="1">
-## Route Details<a name="Route-Details"></a>
+## Route Details
 
 Selecting a route label from the list focuses on that single route on the map, as shown below, and brings up the 'Route Details' panel on the left. The panel includes percentage of completion for a route if it's being worked on, progress bar of completion, the driver(s) assigned to the route, the driver's contact information, and the status of the route along with a timestamp of that status. On this 'Route Details' panel, the user is also able to 'Assign new drivers' to this route and review the near-real time progress of the driver by looking at the breadcrumbs on the route. Breadcrumbs appear as the driver completes the route as shown below. 
 

--- a/sa-supervisor-activities.md
+++ b/sa-supervisor-activities.md
@@ -10,10 +10,10 @@ platform: true
 comments: true
 ---
 <section id="Supervisor-Activities" markdown="1">
-# Supervisor Activities<a name="Supervisor-Assignments"></a>
+# Supervisor Activities
 
 <section id="Creating-New-Assignments" markdown="1">
-## Creating New Assignments<a name="Creating-New-Assignments"></a>
+## Creating New Assignments
 
 There are three ways of creating new assignments within the SA: 
 1. From the Routes tab by pressing 'Assign new drivers'. 
@@ -21,7 +21,7 @@ There are three ways of creating new assignments within the SA:
 3. From the Map Monitoring view on either the Routes or Drivers
 
 <section id="Assigning-New-Drivers" markdown="1">
-### Assigning New Drivers<a name="Assigning-New-Drivers"></a>
+### Assigning New Drivers
 
 A Supervisor can assign a new driver to a route, by following the steps below:
 
@@ -47,7 +47,7 @@ A Supervisor can assign a new driver to a route, by following the steps below:
 </section>
 
 <section id="Adding-Tasks" markdown="1">
-### Adding Tasks<a name="Adding-Tasks"></a>
+### Adding Tasks
 
 A Supervisor can add a new task to a Driver, by preforming the following the steps below:
 
@@ -74,7 +74,7 @@ A Supervisor can add a new task to a Driver, by preforming the following the ste
 </section>
 
 <section id="Creating-Address-Specific-Assignment" markdown="1">
-### Creating Address Specific Assignment<a name="-Creating-Address-Specific-Assignment"></a>
+### Creating Address Specific Assignment
 
 A Supervisor can create an Assignment related to a specific address by following the steps below:
 
@@ -99,7 +99,7 @@ A Supervisor can create an Assignment related to a specific address by following
 </section>
 
 <section id="Completing-Assignments-for-Multi-Passes" markdown="1">
-## Completing Assignments for Multi-Passes<a name="Completing-Assignment-for-Multi-Passes"></a>
+## Completing Assignments for Multi-Passes
 
 A multi-pass Assignment (when assignment was created, the multi-pass toggle was switched to On) requires a Supervisor to determine the next step after each pass completed by the Driver. Once the Driver completes a pass, a Supervisor receives a 'Pass Completion Notice' prompt with the details about the assignment, including the number of passes made, as seen below. A Supervisor has two options: either 
 1. Tap 'Another Pass' to notify the Driver to continue working on the assignment or
@@ -112,7 +112,7 @@ If a Supervisor selects 'Option 1' the system notifies the Driver to continue wo
 </section>
 
 <section id="Cancelling-Assignments" markdown="1">
-## Cancelling Assignments<a name="Cancelling-Assignments"></a>
+## Cancelling Assignments
 
 Supervisor can cancel assignments following these steps:
 
@@ -129,9 +129,9 @@ Supervisor can cancel assignments following these steps:
 </section>
 
 <section id="Routes" markdown="1">
-## Routes<a name="Routes"></a>
+## Routes
 <section id="Inspecting-Routes" markdown="1">
-### Inspecting Routes<a name="-Inspecting-Routes"></a>
+### Inspecting Routes
 
 Once a Route has all its assignments completed, a Supervisor needs to change the status of that route to 'Inspected' to verify that the route is finished, by navigating to the Route Details panel and pressing 'Change Status' and then pressing 'Inspected' on the prompt.
  
@@ -141,13 +141,13 @@ Once a Route has all its assignments completed, a Supervisor needs to change the
 </section>
 
 <section id="Drivers" markdown="1">
-## Drivers<a name="Drivers"></a>
+## Drivers
 
 <section id="Changing-Driver-Status" markdown="1">
-### Changing Driver Status<a name="Changing-Driver-Status"></a>
+### Changing Driver Status
 
 <section id="Assigning-Drivers-to-Tickets" markdown="1">
-#### Assigning Drivers to Tickets<a name="Assigning-Drivers-to-Tickets"></a>
+#### Assigning Drivers to Tickets
 
 A Supervisor can assign an existing ticket to a Driver, by following the steps below:
 
@@ -174,7 +174,7 @@ This will remove the 'New' tag from the ticket on the ticket list and change the
 </section>
 
 <section id="Pausing-or-Resuming-Drivers" markdown="1">
-#### Pausing or Resuming Drivers<a name="Pausing-or-Resuming-Drivers"></a>
+#### Pausing or Resuming Drivers
 
 A Supervisor can pause an active Assignment that a Driver is working on by following the steps below: (the reasons to pause: refil salt or go to gas station to document that no work is being performed on the route – no breadcrumbs are accumulated) 
 
@@ -196,10 +196,10 @@ When the Driver status is 'In Service', a Supervisor can pause an Active Assignm
  </section>
 
 <section id="Road-Hazards" markdown="1">
-## Road Hazards<a name="Road-Hazards"></a>
+## Road Hazards
 
 <section id="Creating-Road-Hazards" markdown="1">
-### Creating Road Hazards<a name="Creating-Road-Hazards"></a>
+### Creating Road Hazards
 
 A Supervisor can create a road hazard on the map to warn Drivers of the hazards on their routes, by following the steps below:
 * From the Map Monitoring view (either tab: Routes, Drivers, or Tickets), tap on the map where the road hazard is located
@@ -217,7 +217,7 @@ A Supervisor can create a road hazard on the map to warn Drivers of the hazards 
 </section>
 
 <section id="Deleting-Road-Hazards" markdown="1">
-### Deleting Road Hazards<a name="Deleting-Road-Hazards"></a>
+### Deleting Road Hazards
 
 A Supervisor can delete an existing road hazard from the map if it doesn't exist anymore:
 

--- a/sa-tickets-tab.md
+++ b/sa-tickets-tab.md
@@ -10,7 +10,7 @@ platform: true
 comments: true
 ---
 <section id="Tickets-Tab-View" markdown="1">
-# Tickets Tab View<a name="Tickets-Tab-View"></a>
+# Tickets Tab View
 
 When Admin sends a new ticket to a Supervisor it will be appear as a ticket count on the Ticket tab for the Supervisor, as seen below.
 
@@ -25,24 +25,24 @@ A new Ticket is notated with a 'New' tag and identified with a red asterisk mark
 <img src="image/supervisor/tickets-tab1-ios.png" class="ios"/>
 
 <section id="Ticket-Filters" markdown="1">
-## Ticket Filters<a name="Ticket-Filters"></a>
+## Ticket Filters
 
 Using the filters on the side panel allows Supervisors to define a more focused look at the MC311 tickets. Setting a filter can add or remove map elements such as the depot that would limit the area displayed on the map to the depot selected, route outlines, ticket status, or ticket types. The filters and their options can be seen below:
 
 <section id="Depot" markdown="1">
-### Depot<a name="-Depot"></a>
+### Depot
 
 The depot filter defaults to the depot the Supervisor is assigned to and only displays the tickets within that Depot's service area. 
 </section>
 
 <section id="Route" markdown="1">
-### Route<a name="-Route"></a>
+### Route
 
 The route filter allows users to filter tickets by a specific route number, which would display only the tickets in proximity to that route. 
 </section>
 
 <section id="Ticket-Status" markdown="1">
-### Ticket Status<a name="-Ticket-Status"></a>
+### Ticket Status
 
 Ticket Status filter allows users to view any ticket set to a specific status.
 
@@ -58,7 +58,7 @@ Ticket Status filter allows users to view any ticket set to a specific status.
 </section>
 
 <section id="Ticket-Type" markdown="1">
-### Ticket Type<a name="Ticket-Type"></a>
+### Ticket Type
 
 Ticket Type filter allows users to filter by two different types of tickets. 
 
@@ -73,7 +73,7 @@ A Checkmark on either type of ticket indicates that the ticket is closed.
 </section>
 
 <section id="Ticket-Details" markdown="1">
-## Ticket Details<a name="Ticket-Details"></a>
+## Ticket Details
 
 Selecting a ticket label from the list focuses on that single ticket on the map and brings up the 'Ticket details' panel on the left. The panel includes all the relevant ticket information and allows the Supervisor to 'Assign drivers' to that ticket. 
 

--- a/soc-active-storm-log-report.md
+++ b/soc-active-storm-log-report.md
@@ -11,17 +11,17 @@ comments: true
 ---
 
 <section id="Active-Storm-LogReport" markdown="1">
-# Active Storm Log/Report<a name="Active-Storm-Log-Report"></a>
+# Active Storm Log/Report
 
 <section id="Active-Storm-Log" markdown="1">
-## Active Storm Log<a name="Active-Storm-Log"></a>
+## Active Storm Log
 
 The Active Storm Log page is an Event Log that allows Admin users a closer look into the actions, the users, and timestamps of the actions for the current active Event. As seen below, the log shows the time the action occurred in the system, what the action was, and who performed it (user name or system). Actions may include creating an Assignment, activating a new Phase for a Depot, or changing the status of a Driver. 
 
 ![Screenshot 2021-03-04 144521](/image/portal/active-storm-log.png)
 
 <section id="Previous-Event-Log" markdown="1">
-### Previous Event Log<a name="Previous-Event-Log"></a>
+### Previous Event Log
 
 To view the Event Log for a previous Event, open the navigation menu and select the Event Management option. After searching for the specific event, click the 'Event Log' button as seen below, and the next page would display the Event Log for the specified Event in the same format as in the screenshot in the previous section above. 
 
@@ -30,18 +30,18 @@ To view the Event Log for a previous Event, open the navigation menu and select 
 </section>
 
 <section id="Active-Storm-Report" markdown="1">
-## Active Storm Report<a name="Active-Storm-Report"></a>
+## Active Storm Report
 
 The Active Storm Report page allows Admin users to view Event Progress in the Statistics Dashboard, using widgets and graphs that are updated in near-real time. The default tab 'Storm Event' that opens is the overall county statistics for the Event with data such as when the event activated and ended, predicted duration, active staff, miles plowed, total snowfall, and salt usage. More granular reporting can be found in other tabs: Phase, Route, Driver, and Salt Usage.
 
 <section id="Storm-Event-Tab" markdown="1">
-### Storm Event Tab<a name="Storm-Event-Tab"></a>
+### Storm Event Tab
 
 ![Screenshot 2021-03-04 144609](/image/portal/storm-event-tab.png)
 </section>
 
 <section id="Phase-Tab" markdown="1">
-### Phase Tab<a name="Phase-Tab"></a>
+### Phase Tab
 
 This tab allows to filter the Phase Statistics by Depot.
 
@@ -49,7 +49,7 @@ This tab allows to filter the Phase Statistics by Depot.
 </section>
 
 <section id="Route-Tab" markdown="1">
-### Route Tab<a name="Route-Tab"></a>
+### Route Tab
 
 This tab allows to filter the Route Statistics by Depot, Phase, and Route Type. 
 
@@ -57,7 +57,7 @@ This tab allows to filter the Route Statistics by Depot, Phase, and Route Type.
 </section>
 
 <section id="Driver-Tab" markdown="1">
-### Driver Tab<a name="Driver-Tab"></a>
+### Driver Tab
 
 This tab allows to view individual Driver statistics by searching for a specific Driver by name or ID. 
 
@@ -65,7 +65,7 @@ This tab allows to view individual Driver statistics by searching for a specific
 </section>
 
 <section id="Salt-Usage-Tab" markdown="1">
-### Salt Usage Tab<a name="Salt-Usage-Tab"></a>
+### Salt Usage Tab
 
 This tab allows to filter Salt Usage statistics by Depot and Phase. 
 
@@ -73,7 +73,7 @@ This tab allows to filter Salt Usage statistics by Depot and Phase.
 </section>
 
 <section id="Previous-Event-Reports" markdown="1">
-### Previous Event Reports<a name="Previous-Event-Reports"></a>
+### Previous Event Reports
 
 To view the Event Log for a previous Event, open the navigation menu and select the Event Management option. After searching for the specific event, click the 'Event Log' button as seen below, and the next page would display the Event Log for the specified Event in the same format as in the screenshot in the previous section above. 
 

--- a/soc-active-storm-ops.md
+++ b/soc-active-storm-ops.md
@@ -11,10 +11,10 @@ comments: true
 ---
 
 <section id="Active-Storm-Ops" markdown="1">
-# Active Storm Ops<a name="Active-Storm-Ops"></a>
+# Active Storm Ops
 
 <section id="Map-Monitoring-View" markdown="1">
-## Map Monitoring View<a name="Map-Monitoring-View"></a>
+## Map Monitoring View
 
 The Map Monitoring view is the first page that users see when logging in, which can also be accessed from the navigation menu on the left under 'Active Storm Ops' option. This page is used to view near-real time visual updates during a storm event. The Map Monitoring view consists of the following elements:
 
@@ -26,12 +26,12 @@ The Map Monitoring view is the first page that users see when logging in, which 
   ![Screenshot 2021-03-04 130851](/image/portal/map-monitoring-view.png)  
 
 <section id="Filters" markdown="1">
-### Filters<a name="Filters"></a>
+### Filters
 
 Using the filters at the top of the Map Monitoring view allows users to narrow down what is seen on the map. Setting a filter can add or remove map elements such as route outlines, routes of different priorities, and routes/drivers that belong to a specific depot. Below are the filters and their options:
 
 <section id="Route-Status" markdown="1">
-#### Route Status<a name="Route-Status"></a>
+#### Route Status
 
 The Route Status filter allows users to view any routes set to a specific status during an assignment.
 
@@ -44,7 +44,7 @@ The Route Status filter allows users to view any routes set to a specific status
 </section>
 
 <section id="Priority" markdown="1">
-#### Priority<a name="Priority"></a>
+#### Priority
 
 The Priority filter allows users to view only specific route details and segments based on their priority. The route segments are displayed as color coded lines on the map.
 
@@ -58,7 +58,7 @@ Route segments (map layer). Routes are represented by different type of route se
 </section>
 
 <section id="Depot" markdown="1">
-#### Depot<a name="Depot"></a>
+#### Depot
 
 The Depot filter allows users to select a depot within the county which narrows down what drivers and routes are displayed on the map and on the tabs to the left of the map.
 
@@ -68,7 +68,7 @@ The Depot filter allows users to select a depot within the county which narrows 
 </section>
 
 <section id="Routes-Tab" markdown="1">
-## Routes Tab<a name="Routes-Tab"></a>
+## Routes Tab
 
 The Routes tab located to the left of the map, as seen below, displays a list of routes with their corresponding route name/number and a status indicator (color coded – see markers), the total number of miles on the route, and the percentage of completion if there is an active assignment. Applying Filters above the map will filter the routes on this tab as well. Clicking on any of the route labels within the tab focuses on that single route on the map.
 
@@ -76,7 +76,7 @@ The Routes tab located to the left of the map, as seen below, displays a list of
 </section>
 
 <section id="Drivers-Tab" markdown="1">
-## Drivers Tab<a name="Drivers-Tab"></a>
+## Drivers Tab
 
 The Drivers tab to the right of the Routes tab, as seen below, displays a list of Drivers with their names and statuses (color coded – see markers and Status Descriptions). When selecting a Driver from the list, their details will be shown above their icon located on the map as seen below. It provides additional details like the Driver's photo, Supervisor name, and the last time the Driver was seen using the Driver App (DA). 
 
@@ -88,14 +88,14 @@ Clicking on the Blue arrow to the right of the Driver name produces the Driver's
 </section>
 
 <section id="Markers" markdown="1">
-## Markers<a name="Markers"></a>
+## Markers
 
 ![Screenshot 2021-03-04 131133](/image/portal/markers.png)
 ![Screenshot 2021-03-04 131156](/image/portal/markers1.png)
 </section>
 
 <section id="Clusters" markdown="1">
-## Clusters<a name="Clusters"></a>
+## Clusters
 
 On the Map Monitoring view,  when a user zooms outs, markers with numbers inside them appear called 'clusters' that de-clutter the map and group together like markers. Clicking on a cluster allows the user to zoom in on that area and view the separated markers on the map. 
 </section>

--- a/soc-event-management.md
+++ b/soc-event-management.md
@@ -11,7 +11,7 @@ comments: true
 ---
 
 <section id="Event-Management" markdown="1">
-# Event Management<a name="Event-Management"></a>
+# Event Management
 
 The Event Management page allows Admin users to create new storm events, edit Event details, create Phases, Activities for Depots during an event, as well as view Event Logs and Reports for each Event. 
 
@@ -19,7 +19,7 @@ The Event Management page allows Admin users to create new storm events, edit Ev
 ![Screenshot 2021-03-05 080423](/image/portal/event-management.png)
 
 <section id="Event-Creation" markdown="1">
-## Event Creation<a name="Event-Creation"></a>
+## Event Creation
 
 When a snow storm is approaching, to plan the event before it occurs (there are no restrictions in the system – 48 hours ahead should suffice), an Admin user can create a new storm event on the Event Management page by following the steps below:
 
@@ -39,7 +39,7 @@ When a snow storm is approaching, to plan the event before it occurs (there are 
   * Active - only one active event at a time
 
 <section id="Phase-Creation-and-Management" markdown="1">
-### Phase Creation and Management<a name="Phase-Creation-and-Management"></a>
+### Phase Creation and Management
 
 Phases are used during a storm Event to define specific Activities that allow proper planning of Assignments for Drivers. Once the newly created Event is on the list, as described in the previous section, the Admin user can create and manage Phases by following the steps below:
 
@@ -97,7 +97,7 @@ Phases are used during a storm Event to define specific Activities that allow pr
 </section>
 
 <section id="Event-Activation-and-Phase-Activation" markdown="1">
-## Event Activation and Phase Activation<a name="Event-Activation-and-Phase-Activation"></a>
+## Event Activation and Phase Activation
 
 Once the creation of Phases and Assignments is completed, the next step is to activate the Event, by following the steps below:
 
@@ -129,7 +129,7 @@ Once the creation of Phases and Assignments is completed, the next step is to ac
 </section>
 
 <section id="Event-Archiving" markdown="1">
-## Event Archiving<a name="Event-Archiving"></a>
+## Event Archiving
 
 Once the Event has been completed to the Admin's specifications, the Event can be closed out by clicking the 'Archive' button, as shown below. Archiving officially closes the Event in the system and allows activation of another event. 
 
@@ -141,7 +141,7 @@ If there are active assignments, the system will prompt with a warning as shown 
 </section>
 
 <section id="Event-Log" markdown="1">
-## Event Log<a name="Event-Log"></a>
+## Event Log
 
 The Event Log button, as shown below, allows users to view all actions taken during a Storm Event, wqhich includes assignment/event status changes, driver status changes, etc. More details can be found on **SOC - Active Storm Log/Report**
 
@@ -149,7 +149,7 @@ The Event Log button, as shown below, allows users to view all actions taken dur
 </section>
 
 <section id="Event-Report" markdown="1">
-## Event Report<a name="Event-Report"></a>
+## Event Report
 
 The Reports button, as shown below, provides a visual representation of statistical data in a dashboard format for the selected Event. More details can be found on **SOC - Active Storm Log/Report**
 

--- a/soc-login-and navigation.md
+++ b/soc-login-and navigation.md
@@ -11,10 +11,10 @@ comments: true
 ---
 
 <section id="Login-and-Navigation" markdown="1">
-# Login and Navigation<a name="Login-and-Navigation"></a>
+# Login and Navigation
 
 <section id="Login" markdown="1">
-## Login<a name="Login"></a>
+## Login
 
 The login screen below allows users to enter into the SNOWiQ Storm Operations Center (SOC) web portal. Click the appropriate 'Login' button to be re-routed to enter the assigned User Name and Password for the application.
 
@@ -28,14 +28,14 @@ Once logged into the SOC, all users will see the Map Monitoring view as seen bel
 </section>
 
 <section id="Navigation" markdown="1">
-## Navigation<a name="Navigation"></a>
+## Navigation
 
 Users can find the navigation menu to access the other pages in the portal by clicking the 'Menu' button (3 stacked lines) at the top left of the application. The options below are available in the left navigation menu bar:
 
 ![Screenshot 2021-03-04 105800](/image/supervisor/navigation-menu.png)
 
 <section id="Active-Storm-Ops" markdown="1">
-### Active Storm Ops<a name="Active-Storm-Ops"></a>
+### Active Storm Ops
 
 The Active Storm Ops page allows users to view the real-time visual progress of the storm event. This includes Routes data (how much has been salted/plowed, what is remaining, number of passes made, etc.) and Drivers data (task progress, driver details, driver location, etc.).
 
@@ -43,7 +43,7 @@ The Active Storm Ops page allows users to view the real-time visual progress of 
 </section>
 
 <section id="Active-Storm-Log" markdown="1">
-### Active Storm Log<a name="Active-Storm-Log"></a>
+### Active Storm Log
 
 The Active Storm Log page is an Event Log that allows Admin users to view all the activities pertaining to the active event as seen below (user logins, status changes, etc.).
 
@@ -51,7 +51,7 @@ The Active Storm Log page is an Event Log that allows Admin users to view all th
 </section>
 
 <section id="Active-Storm-Report" markdown="1">
-### Active Storm Report<a name="Active-Storm-Report"></a>
+### Active Storm Report
 
 The Active Storm Report page allows Admin users to look at the details of the Event progress in the SNOWiQ Statistics Dashboard. The main tab 'Storm Event' includes statistics such as miles plowed, active staff, snow fall, and salt usage. More granular reporting can be found in other tabs: Phase, Route, Driver, and Salt Usage.
 
@@ -59,7 +59,7 @@ The Active Storm Report page allows Admin users to look at the details of the Ev
 </section>
 
 <section id="Event-Management" markdown="1">
-### Event Management<a name="Event-Management"></a>
+### Event Management
 
 The Event Management page allows users to create new Events as storms are announced, create Phases within those events, archive active storms, and view reports on specific storms as well.
 
@@ -67,7 +67,7 @@ The Event Management page allows users to create new Events as storms are announ
 </section>
 
 <section id="MC311-Tickets" markdown="1">
-### MC311 Tickets<a name="MC311-Tickets"></a>
+### MC311 Tickets
 
 The MC311 system is used by Montgomery County, MD to process emergency ticket requests that come in during the snow storm. The SNOWiQ's MC311 Tickets page allows Admin users to send emergency requests that come in from the MC311 system to Supervisors who will in turn assign them to Drivers during an event.
 
@@ -75,7 +75,7 @@ The MC311 system is used by Montgomery County, MD to process emergency ticket re
 </section>
 
 <section id="User-Management" markdown="1">
-### User Management<a name="User-Management"></a>
+### User Management
 
 The User Management page allows Admin users to view and search for users, edit user information, activate/deactivate users, and upload new users into the portal.
 
@@ -83,7 +83,7 @@ The User Management page allows Admin users to view and search for users, edit u
 </section>
 
 <section id="Route-Plans" markdown="1">
-### Route Plans<a name="Route-Plans"></a>
+### Route Plans
 
 The Route Plans page allows Admin users to view the current version of geo-data used to map routes in a depot. Users can also use this page to upload a new file to update the route mapping within a depot.
 

--- a/soc-mc311-tickets.md
+++ b/soc-mc311-tickets.md
@@ -11,21 +11,21 @@ comments: true
 ---
 
 <section id="MC311-Ticket-Request-Management" markdown="1">
-# MC311 Ticket Request Management<a name="MC311-Ticket-Request-Management"></a>
+# MC311 Ticket Request Management
 
 The MC311 system is used by Montgomery County, MD to process ticket requests that come in during the snow storm. The SNOWiQ's MC311 Tickets page allows Admin users to send the ticket requests imported from MC311 to Supervisors who will in turn assign them to Drivers during an event. Additionally, users are able to create emergency request tickets for specific addresses.
 
 There are two ways to view the tickets: the List view and the Map View, as shown below:
 
 <section id="Ticket-List-View" markdown="1">
-## Ticket List View<a name="Ticket-List-View"></a>
+## Ticket List View
 
 This view is a standard table that allows users to close (blue 'Close' button) or assign (blue 'Send' button) tickets to Supervisors. Additionally, there are multiple filters available to narrow down the list displayed: Service Request (SR) ID, Route Name/Number, Depot, Supervisors the ticket is assigned to, Status Indicator, and Type of Ticket. A user can also filter the tickets by the time they were opened and/or closed.  
 
 ![Screenshot 2021-03-05 100248](/image/portal/mc311-ticket-management.png)
 
 <section id="Ticket-Type" markdown="1">
-### Ticket Type<a name="Ticket-Type"></a>
+### Ticket Type
 
 The Ticket Type filter allows users to view the two different types of tickets. 
 
@@ -38,7 +38,7 @@ A checkmark on either type of ticket indicates that the ticket is closed and has
 </section>
 
 <section id="Ticket-Status" markdown="1">
-### Ticket Status<a name="Ticket-Status"></a>
+### Ticket Status
 
 The Ticket Status filter allows users to view any ticket set to a specific status. 
 
@@ -54,7 +54,7 @@ The Ticket Status filter allows users to view any ticket set to a specific statu
 </section>
 
 <section id="Ticket-Import-Validation-Rules" markdown="1">
-### Ticket Import Validation Rules<a name="Ticket-Import-Validation-Rules"></a>
+### Ticket Import Validation Rules
 
 System identifies the route by the address of the ticket and Checks if the route is being treated/plowed.
 
@@ -65,7 +65,7 @@ System identifies the route by the address of the ticket and Checks if the route
 </section>
 
 <section id="Ticket-Map-View" markdown="1">
-## Ticket Map View<a name="Tickets-Map-View"></a>
+## Ticket Map View
 
 This view provides a panel on the left that lists the tickets and their statuses and also a visual on the map of markers (color coded) that represent tickets to give users an idea of where the tickets are located in the service area. Additionally, clusters are visible when the map is zoomed out.
 
@@ -74,14 +74,14 @@ Clicking on the blue arrow next to the ticket in the left panel or on the marker
 ![Screenshot 2021-03-05 100331](/image/portal/ticket-map-view.png)
 
 <section id="Clusters" markdown="1">
-### Clusters<a name="Clusters"></a>
+### Clusters
 
 When a user zooms outs, markers with numbers inside them appear called 'clusters' that de-clutter the map and group together like markers. Clicking on a cluster allows the user to zoom in on that area and view the separated markers on the map. 
 </section>
 </section>
 
 <section id="Sending-Ticket-Requests" markdown="1">
-## Sending Ticket Requests<a name="Sending-Ticket-Requests"></a>
+## Sending Ticket Requests
 
 In order for the ticket to be worked on, it must go through a sequence of steps, the first of which is to send the ticket to the Supervisor to create an assignment by following the steps below:
 
@@ -95,7 +95,7 @@ In order for the ticket to be worked on, it must go through a sequence of steps,
 </section>
 
 <section id="Closing-Tickets" markdown="1">
-## Closing Tickets<a name="Closing-Tickets"></a>
+## Closing Tickets
 
 An Admin user can manually close the ticket if the ticket is deemed to be invalid, by following the steps below:
 
@@ -113,7 +113,7 @@ If the status of the ticket is 'Assigned' or 'In Progress' a warining prompt wil
 </section>
 
 <section id="Creating-Emergency-Ticket-Requests" markdown="1">
-## Creating Emergency Ticket Requests<a name="Creating-Emergency-Ticket-Requests"></a>
+## Creating Emergency Ticket Requests
 
 An Admin user can manually create an Emergency Ticket by following the steps below:
 

--- a/soc-overview.md
+++ b/soc-overview.md
@@ -9,7 +9,7 @@ has_children: true
 platform: false
 ---
 
-## Storm Operations Center (SOC) <a name="-Storm-Operations-Center-(SOC)"></a> 
+## Storm Operations Center (SOC) 
 **Audience: Storm Operations Managers and Supervisors**
 
 This application is primarily used for planning purposes by the SOC Manager to plan and create storm events, review and send 311 tickets to their respective depots, and view the current progress of all actions currently involved in the county. This application is Web-based but can be accessed on mobile devices (iPads, tablets, etc.), if needed. Old documentation refers to this web applications as Admin Portal.

--- a/soc-route-plans.md
+++ b/soc-route-plans.md
@@ -11,14 +11,14 @@ comments: true
 ---
 
 <section id="Route-Plans" markdown="1">
-# Route Plans<a name="Route-Plans"></a>
+# Route Plans
 
 On the Route Plans page, an Admin user can view the currently used geo-location data for route lines and boundaries for each depot, the timestamp it was uploaded, and its current status. Additionally, the Admin can Upload Plan Files to update the data. Each event in the system is associated with a specific Route Plan version number. 
 
 ![Screenshot 2021-03-05 115857](/image/portal/route-plans.png)
 
 <section id="Uploading-Route-Plans" markdown="1">
-## Uploading Route Plans<a name="Uploading-Route-Plans"></a>
+## Uploading Route Plans
 
 An Admin can upload the geo-location data by following the steps below:
 
@@ -35,7 +35,7 @@ An Admin can upload the geo-location data by following the steps below:
 </section>
 
 <section id="Viewing-Archived-Routes" markdown="1">
-## Viewing Archived Routes<a name="Viewing-Archived-Routes"></a>
+## Viewing Archived Routes
 
 Route Plans are automatically archived once new Route Plan files are uploaded. An Admin can view all the previous Route Plan versions and their upload timestamps by clicking on the name of the Depot in bold (below 'Gaithersburg East' was clicked and the accordion-style list expanded to show the history and the previously archived files). Do NOT click the blue x marker next to the Depot name.
 

--- a/soc-user-management.md
+++ b/soc-user-management.md
@@ -11,12 +11,12 @@ comments: true
 ---
 
 <section id="User-Management" markdown="1">
-# User Management<a name="User-Management"></a>
+# User Management
 
 The User Management view allows the Admin user to view all the users currently uploaded into the system as well as upload Excel files with new users, edit individual users, and Deactivate/ Reactivate users in the system.
 
 <section id="Filters" markdown="1">
-## Filters<a name="Filters"></a>
+## Filters
 
 Using the filters at the top of the application allows the Admin user to narrow down the users displayed on the list. The following filters are available: User Login ID, Name, Roles (Admin, Driver, Inspector, Supervisor), Supervisor or Inspector assigned to the user, and the company the user works for. 
 
@@ -24,7 +24,7 @@ Using the filters at the top of the application allows the Admin user to narrow 
 </section>
 
 <section id="Upload-Users" markdown="1">
-## Upload Users<a name="Upload-Users"></a>
+## Upload Users
 
 The Upload Users function allows Admin users to add users to the system by following the steps below (this feature isn't used as Montgomery County does this on their end and therefore this feature may be deprecated in future releases.)
 
@@ -40,7 +40,7 @@ The Upload Users function allows Admin users to add users to the system by follo
 </section>
 
 <section id="Editing-User-Information" markdown="1">
-## Editing User Information<a name="Editing-User-Information"></a>
+## Editing User Information
 
 An Admin user can edit the personal information of users after they have been uploaded by following the steps below.
 
@@ -54,7 +54,7 @@ An Admin user can edit the personal information of users after they have been up
 </section>
 
 <section id="Deactivating-and-Reactivating-Users" markdown="1">
-## Deactivating and Reactivating Users<a name="Deactivating-and-Reactivating-Users"></a>
+## Deactivating and Reactivating Users
 
 An Admin user can Deactivate users when they are no longer needed in the system or no longer needed to fulfill duties. This would remove the user from showing up in selection lists throughout the application (e.g. task assignment). To deactivate the user, locate the user and click on 'Deactivate' button (shown below) and follow with a 'Yes' to the next prompt. The user has been deactivated, and the button now says 'Reactivate' for that user. To reactivate is the same process, click on 'Reactivate', and the user is live in the system again.
 


### PR DESCRIPTION
## Description
I removed all anchor tags from the site's headings as those are generated automatically anyways. This ensures consistency (both for past and future updates to site and) and better readability when editing, and it eliminates duplicate anchor tags  (that sometimes have slight differences). I also added headings to the DA Install Guide, and added support for the Table of Contents generator to this site.
