### PR TITLE
Hide TOC sidebar on medium-width screen

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,15 +73,6 @@ layout: table_wrappers
   
   
   <nav class="toc">
-    <div class="platform_form">
-      {% if page.platform == true %}
-      <b style="margin-left: 20px;">Platform:</b>
-      <select id="platform" onchange="changePlatform()">
-          <option value="ios">IOS</option>
-          <option value="android">Android</option>
-        </select>
-      {% endif %}
-      </div>
 
     <!-- Using https://github.com/allejo/jekyll-toc -->
     <b>Table of Contents</b>
@@ -120,6 +111,15 @@ layout: table_wrappers
       {% endif %}
     </div>
     <div id="main-content-wrap" class="main-content-wrap">
+      <div class="platform_form">
+        {% if page.platform == true %}
+        <b>Platform:</b>
+        <select id="platform" onchange="changePlatform()">
+            <option value="ios">IOS</option>
+            <option value="android">Android</option>
+        </select>
+        {% endif %}
+      </div>
       {% unless page.url == "/" %}
         {% if page.parent %}
           {%- for node in pages_list -%}
@@ -150,6 +150,7 @@ layout: table_wrappers
           </nav>
         {% endif %}
       {% endunless %}
+      
       <div id="main-content" class="main-content" role="main">
         {% if site.heading_anchors != false %}
           {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -71,15 +71,7 @@ layout: table_wrappers
   </div>
 
   <nav class="toc">
-    <div class="platform_form">
-      {% if page.platform == true %}
-      <b style="margin-left: 20px;">Platform:</b>
-      <select id="platform" onchange="changePlatform()">
-          <option value="ios">IOS</option>
-          <option value="android">Android</option>
-        </select>
-      {% endif %}
-      </div>
+    <!--Empty toc is necessary for styling purposes-->
   </nav>
 
   <div class="main" id="top">
@@ -113,6 +105,15 @@ layout: table_wrappers
       {% endif %}
     </div>
     <div id="main-content-wrap" class="main-content-wrap">
+      <div class="platform_form">
+        {% if page.platform == true %}
+        <b>Platform:</b>
+        <select id="platform" onchange="changePlatform()">
+            <option value="ios">IOS</option>
+            <option value="android">Android</option>
+        </select>
+        {% endif %}
+      </div>
       {% unless page.url == "/" %}
         {% if page.parent %}
           {%- for node in pages_list -%}

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -107,7 +107,11 @@
   display:none;
 
   @include mq(md) {
-    
+    display: block;
+    position: absolute;
+    width: 185px;
+    left: calc(100% - 185px);
+    margin-top: -20px;
   }
 
   @include mq(lg) {
@@ -115,6 +119,8 @@
     position: fixed;
     right: 0;
     top: 0;
+    left: calc(100% - #{$nav-width});
+    margin-top:0;
     width: $nav-width;
     height: 60px;
     padding-left: 0;
@@ -122,6 +128,14 @@
     border-bottom: $border $border-color;
     border-left: $border $border-color;
     line-height:60px;
+  }
+}
+
+// Platform selection feature heading
+.platform_form b {
+  @include mq(lg) {
+  margin-left: 20px;
+  font-size: 17px;
   }
 }
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -63,27 +63,24 @@
 // not including platform selection feature located above
 .toc {
   display:none;
-  padding-left: 0;
-  padding-right: 12px;
-  right: 0;
-  top: 60px;
-  bottom: 0;
-  overflow-y: auto;
-  //margin-left: calc($nav-width-md + $content-width);
-  background-color: $sidebar-color;
 
   @include mq(md) {
-    display:block;
-    //flex-wrap: nowrap;
-    position: fixed;
-    width: $nav-width-md;
-    height: calc(100% - 60px);
-    border-left: $border $border-color;
-    padding-top: 8px;
+    
   }
 
   @include mq(lg) {
-    min-width: $nav-width;
+    display:block;
+    position: fixed;
+    right: 0;
+    top: 60px;
+    bottom: 0;
+    width: $nav-width;
+    background-color: $sidebar-color;
+    border-left: $border $border-color;
+    padding-top: 8px;
+    padding-left: 0;
+    padding-right: 12px;
+    overflow-y: auto;
   }
 }
 
@@ -140,7 +137,6 @@
   position: relative;
   max-width: $content-width;
   margin-left: $nav-width-md;
-  margin-right: $nav-width-md;
 }
 
 @include mq(lg) {

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -3,21 +3,19 @@
 
 }
 
-// ios content
+// android content
 .content-android{
 
 }
 
 
 // left side-bar
-// .side-bar on small screen
 .side-bar {
   z-index: 0;
   display: flex;
   flex-wrap: wrap;
   background-color: $sidebar-color;
 
-  // .side-bar on medium screen
   @include mq(md) {
     //flex-wrap: nowrap;
     position: fixed;
@@ -28,7 +26,6 @@
     align-items: flex-end;
   }
 
-  // .side-bar on large screen
   @include mq(lg) {
     min-width: $nav-width;
   }
@@ -49,14 +46,12 @@
 }
 
 // site navigation located in left side-bar
-// #site-nav on small screen
 #site-nav{
   overflow-y: auto;
   height: 500px;
   padding-top: 0px;
   margin-top: 25px;
-  
-  // #site-nav on medium screen
+
   @include mq(md) {
     height: 0;
   }
@@ -66,7 +61,6 @@
 
 // table of contents side-bar
 // not including platform selection feature located above
-// .toc on small screen
 .toc {
   display:none;
   padding-left: 0;
@@ -78,7 +72,6 @@
   //margin-left: calc($nav-width-md + $content-width);
   background-color: $sidebar-color;
 
-  // .toc on medium screen
   @include mq(md) {
     display:block;
     //flex-wrap: nowrap;
@@ -89,7 +82,6 @@
     padding-top: 8px;
   }
 
-  // .toc on large screen
   @include mq(lg) {
     min-width: $nav-width;
   }
@@ -114,7 +106,6 @@
 }
 
 // header above table of contents including platform selection feature
-// .platform_form on small screen
 .platform_form {
   display:none;
   padding-left: 0;
@@ -123,7 +114,6 @@
   //margin-left: calc($nav-width-md + $content-width);
   background-color: $sidebar-color;
 
-  // .platform_form on medium screen
   @include mq(md) {
     display:block;
     //flex-wrap: nowrap;
@@ -135,7 +125,6 @@
     line-height:60px;
   }
 
-  // .platform_form on large screen
   @include mq(lg) {
     //width: calc((100% - #{$nav-width + $content-width}) / 2 + #{$nav-width});
     min-width: $nav-width;
@@ -147,7 +136,6 @@
 // main content
 // including search and aux-link bar
 .main {
-// .main on medium screen
 @include mq(md) {
   position: relative;
   max-width: $content-width;
@@ -155,7 +143,6 @@
   margin-right: $nav-width-md;
 }
 
-// .main on large screen
 @include mq(lg) {
   margin-left: $nav-width;
   margin-right: $nav-width;
@@ -173,11 +160,9 @@
 }
 
 // aux-link in top-bar
-// .aux-nav on small screen
 .aux-nav {
   display:none;
 
-  // .aux-nav on medium screen
   @include mq(md) {
     display:block;
   }

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -64,10 +64,6 @@
 .toc {
   display:none;
 
-  @include mq(md) {
-    
-  }
-
   @include mq(lg) {
     display:block;
     position: fixed;

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -105,26 +105,23 @@
 // header above table of contents including platform selection feature
 .platform_form {
   display:none;
-  padding-left: 0;
-  right: 0;
-  top: 0;
-  //margin-left: calc($nav-width-md + $content-width);
-  background-color: $sidebar-color;
 
   @include mq(md) {
-    display:block;
-    //flex-wrap: nowrap;
-    position: fixed;
-    width: $nav-width-md;
-    height: 60px;
-    border-bottom: $border $border-color;
-    border-left: $border $border-color;
-    line-height:60px;
+    
   }
 
   @include mq(lg) {
-    //width: calc((100% - #{$nav-width + $content-width}) / 2 + #{$nav-width});
-    min-width: $nav-width;
+    display:block;
+    position: fixed;
+    right: 0;
+    top: 0;
+    width: $nav-width;
+    height: 60px;
+    padding-left: 0;
+    background-color: $sidebar-color;
+    border-bottom: $border $border-color;
+    border-left: $border $border-color;
+    line-height:60px;
   }
 }
 


### PR DESCRIPTION
## Type of change
Change to layout

## Description
The Table of Contents sidebar will now be hidden on screens with a medium-sized width, as the content-width was very small before. The platform selection feature now moves to the top right of the content on screens with a medium-sized width.

Additional commit:
The platform selection feature will now also be displayed on small and xs (e.g. mobile devices) screens.
