### PR TITLE
Sidebar width/ layout change thresholds

### DIFF
--- a/_sass/color_schemes/foo.scss
+++ b/_sass/color_schemes/foo.scss
@@ -1,6 +1,6 @@
 // change layout by setting the sidebar width to a set size
-$nav-width: 250px;
-$nav-width-md: 250px;
+$nav-width: 265px;
+$nav-width-md: 265px;
 $content-width: calc(100% - #{$nav-width});
 
 // change color of all links
@@ -8,3 +8,11 @@ $link-color: $blue-000;
 
 // change color of heading in top left
 $body-heading-color: rgb(13, 108, 224);
+
+$media-queries: (
+  xs: 320px,
+  sm: 500px,
+  md: $nav-width + 675px,
+  lg: 2 * $nav-width + 675px,
+  xl: 1400px,
+) ;

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -69,7 +69,7 @@ body::-webkit-scrollbar-track {
   color: #FFFFFF;
   padding-top: $sp-4;
   padding-bottom: $sp-4;
-  font-size: 18px !important;
+  font-size: 20px !important;
 }
 
 // site navigation located in left side-bar
@@ -232,10 +232,6 @@ iframe {
     height:270px;
   }
   @include mq(md) {
-    width:510px;
-    height:287px;
-  }
-  @include mq(lg) {
     width:600px;
     height:340px;
   }


### PR DESCRIPTION
## Type of change
Change to layout

## Description
- increased width of sidebars (navigation, toc) by 15px for better visuals and to avoid line breaks in navigation

- changed layout change thresholds to avoid tiny content column on some screen sizes
-> default xs, sm, xl values
-> increased md, lg values, so that the content column is always at least 675px wide

- minor changes in custom.scss to complement the layout changes
